### PR TITLE
Add ARC agent prototype v2 (FluidSeed grid-world agent)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -424,3 +424,6 @@ auth/users.json
 *.pem
 *.cert
 security_config.yaml.backup
+
+# ARC agent prototype generated artifacts
+agent_trajectory.png

--- a/arc_agent_prototype_v2.py
+++ b/arc_agent_prototype_v2.py
@@ -36,10 +36,16 @@ class SimpleGridEnv:
         self.reset()
 
     def reset(self):
-        self.agent_pos = np.array([np.random.randint(0, self.size), np.random.randint(0, self.size)])
-        self.goal_pos = np.array([np.random.randint(0, self.size), np.random.randint(0, self.size)])
+        self.agent_pos = np.array(
+            [np.random.randint(0, self.size), np.random.randint(0, self.size)]
+        )
+        self.goal_pos = np.array(
+            [np.random.randint(0, self.size), np.random.randint(0, self.size)]
+        )
         while np.array_equal(self.agent_pos, self.goal_pos):
-            self.goal_pos = np.array([np.random.randint(0, self.size), np.random.randint(0, self.size)])
+            self.goal_pos = np.array(
+                [np.random.randint(0, self.size), np.random.randint(0, self.size)]
+            )
         self.steps = 0
         self.done = False
         return self.get_state()
@@ -53,7 +59,7 @@ class SimpleGridEnv:
     def step(self, action):
         if self.done:
             return self.get_state(), 0, True
-        moves = {'up': [-1, 0], 'down': [1, 0], 'left': [0, -1], 'right': [0, 1]}
+        moves = {"up": [-1, 0], "down": [1, 0], "left": [0, -1], "right": [0, 1]}
         if action in moves:
             new_pos = self.agent_pos + moves[action]
             if 0 <= new_pos[0] < self.size and 0 <= new_pos[1] < self.size:
@@ -71,31 +77,31 @@ class FluidSeedAgent:
         self.agent_pos = None
         # Immutable Seed Rules
         self.seed_rules = {
-            'fidelity': True,   # Maximize intent modeling
-            'humility': True,   # Explore on uncertainty
-            'integrity': True,  # Log adaptations
+            "fidelity": True,  # Maximize intent modeling
+            "humility": True,  # Explore on uncertainty
+            "integrity": True,  # Log adaptations
         }
 
     def act(self, state, step):
         # Simple probing: random if no belief, else towards believed goal
         if not self.belief or self.agent_pos is None:
-            actions = ['up', 'down', 'left', 'right']
+            actions = ["up", "down", "left", "right"]
             action = np.random.choice(actions)
         else:
             # Derivative-like: move towards goal
-            dx = self.belief['goal'][0] - self.agent_pos[0]
-            dy = self.belief['goal'][1] - self.agent_pos[1]
+            dx = self.belief["goal"][0] - self.agent_pos[0]
+            dy = self.belief["goal"][1] - self.agent_pos[1]
             if abs(dx) > abs(dy):
-                action = 'down' if dx > 0 else 'up'
+                action = "down" if dx > 0 else "up"
             else:
-                action = 'right' if dy > 0 else 'left'
+                action = "right" if dy > 0 else "left"
         self.trajectory.append((step, action))
         return action
 
     def update(self, state, reward, done, agent_pos):
         self.agent_pos = agent_pos
         if reward > 0:
-            self.belief['goal'] = list(agent_pos)  # Update from feedback (derivative)
+            self.belief["goal"] = list(agent_pos)  # Update from feedback (derivative)
         if done:
             print("Seed Rules Enforced:", self.seed_rules)
 
@@ -105,9 +111,9 @@ def visualize_trajectory(env, trajectory, title="Agent Trajectory"):
     grid = np.zeros((env.size, env.size))
     for pos in trajectory:
         grid[pos[0], pos[1]] = 1
-    ax.imshow(grid, cmap='Blues')
+    ax.imshow(grid, cmap="Blues")
     ax.set_title(title)
-    ax.plot(env.goal_pos[1], env.goal_pos[0], 'r*', markersize=15, label='Goal')
+    ax.plot(env.goal_pos[1], env.goal_pos[0], "r*", markersize=15, label="Goal")
     plt.legend()
     plt.savefig(TRAJECTORY_PATH)
     print("Visualization saved to", TRAJECTORY_PATH)

--- a/arc_agent_prototype_v2.py
+++ b/arc_agent_prototype_v2.py
@@ -1,0 +1,139 @@
+"""ARC Agent Prototype v2.
+
+A minimal "Fluid Seed" agent acting in a simple grid-world environment.
+
+The agent operates under three immutable Seed Rules:
+  * fidelity  - maximize intent modeling
+  * humility  - explore on uncertainty
+  * integrity - log adaptations
+
+It probes the environment, builds a belief about the goal location from
+feedback, and steers toward that belief once it has been discovered. The run
+produces a trajectory visualization.
+
+Output (the trajectory PNG) is written next to this script so the prototype
+runs anywhere without depending on a hardcoded absolute path.
+"""
+
+import os
+
+import matplotlib
+
+# Use a non-interactive backend so the prototype runs in headless environments.
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+OUTPUT_DIR = os.path.dirname(os.path.abspath(__file__))
+TRAJECTORY_PATH = os.path.join(OUTPUT_DIR, "agent_trajectory.png")
+
+
+class SimpleGridEnv:
+    def __init__(self, size=10, seed=42):
+        np.random.seed(seed)
+        self.size = size
+        self.reset()
+
+    def reset(self):
+        self.agent_pos = np.array([np.random.randint(0, self.size), np.random.randint(0, self.size)])
+        self.goal_pos = np.array([np.random.randint(0, self.size), np.random.randint(0, self.size)])
+        while np.array_equal(self.agent_pos, self.goal_pos):
+            self.goal_pos = np.array([np.random.randint(0, self.size), np.random.randint(0, self.size)])
+        self.steps = 0
+        self.done = False
+        return self.get_state()
+
+    def get_state(self):
+        grid = np.zeros((self.size, self.size), dtype=int)
+        grid[self.agent_pos[0], self.agent_pos[1]] = 1
+        grid[self.goal_pos[0], self.goal_pos[1]] = 2
+        return grid.tolist()
+
+    def step(self, action):
+        if self.done:
+            return self.get_state(), 0, True
+        moves = {'up': [-1, 0], 'down': [1, 0], 'left': [0, -1], 'right': [0, 1]}
+        if action in moves:
+            new_pos = self.agent_pos + moves[action]
+            if 0 <= new_pos[0] < self.size and 0 <= new_pos[1] < self.size:
+                self.agent_pos = new_pos
+        self.steps += 1
+        reward = 100 if np.array_equal(self.agent_pos, self.goal_pos) else -1
+        self.done = np.array_equal(self.agent_pos, self.goal_pos) or self.steps > 50
+        return self.get_state(), reward, self.done
+
+
+class FluidSeedAgent:
+    def __init__(self):
+        self.belief = {}  # Simple goal position belief
+        self.trajectory = []
+        self.agent_pos = None
+        # Immutable Seed Rules
+        self.seed_rules = {
+            'fidelity': True,   # Maximize intent modeling
+            'humility': True,   # Explore on uncertainty
+            'integrity': True,  # Log adaptations
+        }
+
+    def act(self, state, step):
+        # Simple probing: random if no belief, else towards believed goal
+        if not self.belief or self.agent_pos is None:
+            actions = ['up', 'down', 'left', 'right']
+            action = np.random.choice(actions)
+        else:
+            # Derivative-like: move towards goal
+            dx = self.belief['goal'][0] - self.agent_pos[0]
+            dy = self.belief['goal'][1] - self.agent_pos[1]
+            if abs(dx) > abs(dy):
+                action = 'down' if dx > 0 else 'up'
+            else:
+                action = 'right' if dy > 0 else 'left'
+        self.trajectory.append((step, action))
+        return action
+
+    def update(self, state, reward, done, agent_pos):
+        self.agent_pos = agent_pos
+        if reward > 0:
+            self.belief['goal'] = list(agent_pos)  # Update from feedback (derivative)
+        if done:
+            print("Seed Rules Enforced:", self.seed_rules)
+
+
+def visualize_trajectory(env, trajectory, title="Agent Trajectory"):
+    fig, ax = plt.subplots(1, 1, figsize=(6, 6))
+    grid = np.zeros((env.size, env.size))
+    for pos in trajectory:
+        grid[pos[0], pos[1]] = 1
+    ax.imshow(grid, cmap='Blues')
+    ax.set_title(title)
+    ax.plot(env.goal_pos[1], env.goal_pos[0], 'r*', markersize=15, label='Goal')
+    plt.legend()
+    plt.savefig(TRAJECTORY_PATH)
+    print("Visualization saved to", TRAJECTORY_PATH)
+    plt.close()
+
+
+def main():
+    env = SimpleGridEnv()
+    agent = FluidSeedAgent()
+    state = env.reset()
+    agent_pos = env.agent_pos.copy()
+    trajectory_positions = [tuple(agent_pos)]
+    done = False
+
+    for step in range(50):
+        action = agent.act(state, step)
+        state, reward, done = env.step(action)
+        agent_pos = env.agent_pos.copy()
+        trajectory_positions.append(tuple(agent_pos))
+        agent.update(state, reward, done, agent_pos)
+        if done:
+            break
+
+    visualize_trajectory(env, trajectory_positions)
+    print("Simulation complete. Goal reached:", done)
+
+
+if __name__ == "__main__":
+    main()

--- a/arc_agent_prototype_v2.py
+++ b/arc_agent_prototype_v2.py
@@ -31,20 +31,21 @@ TRAJECTORY_PATH = os.path.join(OUTPUT_DIR, "agent_trajectory.png")
 
 class SimpleGridEnv:
     def __init__(self, size=10, seed=42):
-        np.random.seed(seed)
+        # Local generator avoids mutating the global numpy RNG state.
+        self.rng = np.random.default_rng(seed)
         self.size = size
         self.reset()
 
     def reset(self):
         self.agent_pos = np.array(
-            [np.random.randint(0, self.size), np.random.randint(0, self.size)]
+            [self.rng.integers(0, self.size), self.rng.integers(0, self.size)]
         )
         self.goal_pos = np.array(
-            [np.random.randint(0, self.size), np.random.randint(0, self.size)]
+            [self.rng.integers(0, self.size), self.rng.integers(0, self.size)]
         )
         while np.array_equal(self.agent_pos, self.goal_pos):
             self.goal_pos = np.array(
-                [np.random.randint(0, self.size), np.random.randint(0, self.size)]
+                [self.rng.integers(0, self.size), self.rng.integers(0, self.size)]
             )
         self.steps = 0
         self.done = False
@@ -71,7 +72,9 @@ class SimpleGridEnv:
 
 
 class FluidSeedAgent:
-    def __init__(self):
+    def __init__(self, seed=42):
+        # Local generator avoids mutating the global numpy RNG state.
+        self.rng = np.random.default_rng(seed)
         self.belief = {}  # Simple goal position belief
         self.trajectory = []
         self.agent_pos = None
@@ -86,7 +89,7 @@ class FluidSeedAgent:
         # Simple probing: random if no belief, else towards believed goal
         if not self.belief or self.agent_pos is None:
             actions = ["up", "down", "left", "right"]
-            action = np.random.choice(actions)
+            action = self.rng.choice(actions)
         else:
             # Derivative-like: move towards goal
             dx = self.belief["goal"][0] - self.agent_pos[0]
@@ -100,24 +103,31 @@ class FluidSeedAgent:
 
     def update(self, state, reward, done, agent_pos):
         self.agent_pos = agent_pos
-        if reward > 0:
-            self.belief["goal"] = list(agent_pos)  # Update from feedback (derivative)
+        # Locate the goal (encoded as 2) in the observed state grid so the
+        # agent forms a belief and can actively steer toward it, rather than
+        # only learning the goal after stumbling onto it.
+        for r, row in enumerate(state):
+            if 2 in row:
+                self.belief["goal"] = [r, row.index(2)]
+                break
         if done:
             print("Seed Rules Enforced:", self.seed_rules)
 
 
 def visualize_trajectory(env, trajectory, title="Agent Trajectory"):
     fig, ax = plt.subplots(1, 1, figsize=(6, 6))
-    grid = np.zeros((env.size, env.size))
-    for pos in trajectory:
-        grid[pos[0], pos[1]] = 1
-    ax.imshow(grid, cmap="Blues")
-    ax.set_title(title)
-    ax.plot(env.goal_pos[1], env.goal_pos[0], "r*", markersize=15, label="Goal")
-    plt.legend()
-    plt.savefig(TRAJECTORY_PATH)
-    print("Visualization saved to", TRAJECTORY_PATH)
-    plt.close()
+    try:
+        grid = np.zeros((env.size, env.size))
+        for pos in trajectory:
+            grid[pos[0], pos[1]] = 1
+        ax.imshow(grid, cmap="Blues")
+        ax.set_title(title)
+        ax.plot(env.goal_pos[1], env.goal_pos[0], "r*", markersize=15, label="Goal")
+        plt.legend()
+        plt.savefig(TRAJECTORY_PATH)
+        print("Visualization saved to", TRAJECTORY_PATH)
+    finally:
+        plt.close(fig)
 
 
 def main():


### PR DESCRIPTION
## Summary

Adds `arc_agent_prototype_v2.py` — a minimal **Fluid Seed** agent acting in a `SimpleGridEnv` grid-world. The agent runs under three immutable Seed Rules (`fidelity`, `humility`, `integrity`), observes the goal, builds a belief about its location, steers toward it, and renders its trajectory as a PNG.

## What's here

- `SimpleGridEnv` — 10×10 grid world with an agent and a goal; `step()` returns `(state, reward, done)`.
- `FluidSeedAgent` — probing agent that forms a goal belief from the observed state grid and steers toward it; logs Seed Rules on episode end.
- `visualize_trajectory()` — saves the trajectory plot next to the script.

Running it prints `Goal reached: True` — the agent navigates to the goal.

## Changes vs. the source draft

The original draft targeted a hardcoded `/home/workdir/` path that doesn't exist in this repo/environment. To make it a runnable, committable prototype:

- Use the non-interactive matplotlib **`Agg` backend** so it runs headless.
- Write the output PNG **next to the script** instead of `/home/workdir/`.
- The generated `agent_trajectory.png` is **gitignored** (build artifact).
- Black-formatted to satisfy the repo's lint config.

## Addressed in code review (Gemini)

- **Local RNG:** use `np.random.default_rng(seed)` in both `SimpleGridEnv` and `FluidSeedAgent` instead of mutating the global numpy seed.
- **Goal-steering belief:** the agent now reads the goal (encoded as `2`) from the observed state grid and steers toward it, instead of only learning the goal after stumbling onto it (which made the original a pure random walk).
- **Safe figure close:** `visualize_trajectory` wraps plotting in `try/finally` so the matplotlib figure is always closed.

## Note on the `lint-test` CI check

`lint-test` runs `black --check .` across the **entire repo** and is failing due to **pre-existing breakage on `master`**, unrelated to this PR: ~8 files contain committed git merge-conflict markers that won't parse (e.g. `agents/executor.py`, `agents/mutator.py`, `analyzers/pattern_detector.py`, `connectors/*`) plus ~25 files that need reformatting. This PR's single added file is black-clean. Fixing the repo-wide debt (a large reformat plus manual merge-conflict resolution) is intentionally **out of scope** here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)