### PR TITLE
Point PatternDetector at the PostgreSQL execution store

### DIFF
--- a/analyzers/pattern_detector.py
+++ b/analyzers/pattern_detector.py
@@ -4,9 +4,10 @@ Pattern Detector for analyzing execution patterns and generating insights.
 """
 
 import logging
-import sqlite3
 from datetime import datetime, timedelta
-from typing import Dict, Any, List, Optional
+from typing import Any, Dict, List
+
+from utils.db_tracker import ensure_tables_exist, get_db_connection
 
 logger = logging.getLogger(__name__)
 
@@ -14,31 +15,37 @@ logger = logging.getLogger(__name__)
 class PatternDetector:
     """
     Analyzes execution patterns and generates insights and recommendations.
-    """
 
-    def __init__(self, db_path: str = "data/executor.db"):
-        self.db_path = db_path
+    Execution history is read from the shared PostgreSQL ``protocol_executions``
+    table that ``utils.db_tracker`` writes to, so the detector sees the same
+    data the rest of the system records.
+    """
 
     async def detect_patterns(self) -> Dict[str, Any]:
         """
-        Detect patterns in execution history.
+        Detect patterns in execution history from the PostgreSQL
+        ``protocol_executions`` table.
 
         Returns:
             Dict[str, Any]: Detected patterns
         """
+        conn = None
         try:
-            conn = sqlite3.connect(self.db_path)
+            # Make sure the executions table exists (no-op if already created).
+            ensure_tables_exist()
+
+            conn = get_db_connection()
             cursor = conn.cursor()
 
-            # Get execution history for the last 7 days
-            seven_days_ago = (datetime.utcnow() - timedelta(days=7)).isoformat()
+            # Look at execution history for the last 7 days.
+            seven_days_ago = datetime.utcnow() - timedelta(days=7)
 
-            # Detect failure patterns
+            # Detect repeated failures.
             cursor.execute(
                 """
-                SELECT protocol_name, COUNT(*) as failure_count
-                FROM execution_history
-                WHERE success = 0 AND timestamp > ?
+                SELECT protocol_name, COUNT(*) AS failure_count
+                FROM protocol_executions
+                WHERE success = FALSE AND execution_time > %s
                 GROUP BY protocol_name
                 HAVING COUNT(*) > 1
                 ORDER BY failure_count DESC
@@ -47,8 +54,7 @@ class PatternDetector:
             )
 
             repeated_failures = []
-            for row in cursor.fetchall():
-                protocol, count = row
+            for protocol, count in cursor.fetchall():
                 severity = "high" if count > 3 else "medium"
                 repeated_failures.append(
                     {
@@ -58,12 +64,17 @@ class PatternDetector:
                     }
                 )
 
-            # Detect performance patterns
+            # Detect slow protocols. Duration is stored inside the JSONB
+            # ``details`` payload, so average only the numeric values present.
             cursor.execute(
-                """
-                SELECT protocol_name, AVG(duration) as avg_duration, COUNT(*) as exec_count
-                FROM execution_history
-                WHERE timestamp > ?
+                r"""
+                SELECT protocol_name,
+                       AVG((details ->> 'duration')::float) AS avg_duration,
+                       COUNT(*) AS exec_count
+                FROM protocol_executions
+                WHERE execution_time > %s
+                  AND details ? 'duration'
+                  AND (details ->> 'duration') ~ '^[0-9]+(\.[0-9]+)?$'
                 GROUP BY protocol_name
                 HAVING COUNT(*) > 2
                 ORDER BY avg_duration DESC
@@ -73,23 +84,22 @@ class PatternDetector:
             )
 
             slow_protocols = []
-            for row in cursor.fetchall():
-                protocol, avg_duration, count = row
-                if avg_duration > 1.0:  # More than 1 second
+            for protocol, avg_duration, count in cursor.fetchall():
+                if avg_duration is not None and avg_duration > 1.0:
                     slow_protocols.append(
                         {
                             "protocol": protocol,
-                            "avg_duration": avg_duration,
+                            "avg_duration": float(avg_duration),
                             "execution_count": count,
                         }
                     )
 
-            # Detect usage patterns
+            # Detect most-used protocols.
             cursor.execute(
                 """
-                SELECT protocol_name, COUNT(*) as usage_count
-                FROM execution_history
-                WHERE timestamp > ?
+                SELECT protocol_name, COUNT(*) AS usage_count
+                FROM protocol_executions
+                WHERE execution_time > %s
                 GROUP BY protocol_name
                 ORDER BY usage_count DESC
                 LIMIT 5
@@ -97,17 +107,12 @@ class PatternDetector:
                 (seven_days_ago,),
             )
 
-            top_protocols = []
-            for row in cursor.fetchall():
-                protocol, count = row
-                top_protocols.append(
-                    {
-                        "protocol": protocol,
-                        "usage_count": count,
-                    }
-                )
+            top_protocols = [
+                {"protocol": protocol, "usage_count": count}
+                for protocol, count in cursor.fetchall()
+            ]
 
-            conn.close()
+            cursor.close()
 
             return {
                 "failure_patterns": {
@@ -129,6 +134,9 @@ class PatternDetector:
                 "usage_patterns": {"top_protocols": []},
                 "error": str(e),
             }
+        finally:
+            if conn is not None:
+                conn.close()
 
     async def generate_insights(
         self,

--- a/analyzers/pattern_detector.py
+++ b/analyzers/pattern_detector.py
@@ -3,6 +3,7 @@
 Pattern Detector for analyzing execution patterns and generating insights.
 """
 
+import asyncio
 import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, List
@@ -10,6 +11,11 @@ from typing import Any, Dict, List
 from utils.db_tracker import ensure_tables_exist, get_db_connection
 
 logger = logging.getLogger(__name__)
+
+# The executions table is ensured once per process (the writer,
+# utils.db_tracker.track_outcome, also creates it on demand), so the read path
+# does not issue CREATE TABLE statements on every call.
+_tables_ready = False
 
 
 class PatternDetector:
@@ -26,13 +32,24 @@ class PatternDetector:
         Detect patterns in execution history from the PostgreSQL
         ``protocol_executions`` table.
 
+        The queries use the synchronous psycopg2 driver, so the blocking work
+        runs in a worker thread to avoid stalling the event loop.
+
         Returns:
             Dict[str, Any]: Detected patterns
         """
+        return await asyncio.to_thread(self._detect_patterns_sync)
+
+    def _detect_patterns_sync(self) -> Dict[str, Any]:
+        """Run the blocking database queries for :meth:`detect_patterns`."""
+        global _tables_ready
         conn = None
         try:
-            # Make sure the executions table exists (no-op if already created).
-            ensure_tables_exist()
+            # Ensure the executions table exists once per process rather than on
+            # every call (the write path also creates it on demand).
+            if not _tables_ready:
+                ensure_tables_exist()
+                _tables_ready = True
 
             conn = get_db_connection()
             cursor = conn.cursor()

--- a/tests/test_pattern_detector.py
+++ b/tests/test_pattern_detector.py
@@ -102,6 +102,27 @@ def test_slow_protocol_below_threshold_is_ignored():
     assert patterns["performance_patterns"]["slow_protocols"] == []
 
 
+def test_ensure_tables_is_called_at_most_once_across_calls():
+    # The executions table is ensured once per process, not on every call.
+    calls = {"n": 0}
+
+    def counting_ensure():
+        calls["n"] += 1
+
+    pd._tables_ready = False
+    try:
+        with patch.object(pd, "ensure_tables_exist", counting_ensure), patch.object(
+            pd, "get_db_connection", lambda: _make_conn([[], [], []])
+        ):
+            detector = pd.PatternDetector()
+            asyncio.run(detector.detect_patterns())
+            asyncio.run(detector.detect_patterns())
+    finally:
+        pd._tables_ready = False
+
+    assert calls["n"] == 1
+
+
 def test_detect_patterns_degrades_gracefully_on_db_error():
     def boom():
         raise RuntimeError("connection refused")

--- a/tests/test_pattern_detector.py
+++ b/tests/test_pattern_detector.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Unit tests for analyzers.pattern_detector.PatternDetector.
+
+These tests exercise the pattern-detection and insight-generation logic
+without a live PostgreSQL server by mocking the ``utils.db_tracker``
+connection helpers. They are written as plain synchronous functions that
+drive the coroutines via ``asyncio.run`` so they run under stock pytest
+regardless of pytest-asyncio configuration.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import analyzers.pattern_detector as pd
+
+
+class _FakeCursor:
+    """Returns canned result sets for the three SELECTs in detect_patterns()."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self._last = []
+
+    def execute(self, sql, params=None):
+        # Hand back the next canned result set for each query in order.
+        self._last = self._results.pop(0)
+
+    def fetchall(self):
+        return self._last
+
+    def close(self):
+        pass
+
+
+def _make_conn(results):
+    conn = MagicMock()
+    conn.cursor.return_value = _FakeCursor(results)
+    return conn
+
+
+def test_analyze_builds_patterns_insights_and_recommendations():
+    failures = [("data_processor", 5), ("api_health_checker", 2)]
+    slow = [("multimodal_llm_analyzer", 3.4, 4)]
+    usage = [("data_processor", 12), ("api_health_checker", 9)]
+
+    with patch.object(pd, "ensure_tables_exist", lambda: None), patch.object(
+        pd, "get_db_connection", lambda: _make_conn([failures, slow, usage])
+    ):
+        result = asyncio.run(pd.PatternDetector().analyze())
+
+    assert result["success"] is True
+
+    patterns = result["patterns"]
+    repeated = patterns["failure_patterns"]["repeated_failures"]
+    assert repeated[0] == {
+        "protocol": "data_processor",
+        "failure_count": 5,
+        "severity": "high",
+    }
+    # count of 2 (> 1 but <= 3) is "medium" severity
+    assert repeated[1]["severity"] == "medium"
+
+    slow_protocols = patterns["performance_patterns"]["slow_protocols"]
+    assert slow_protocols == [
+        {
+            "protocol": "multimodal_llm_analyzer",
+            "avg_duration": 3.4,
+            "execution_count": 4,
+        }
+    ]
+
+    top = patterns["usage_patterns"]["top_protocols"]
+    assert top[0] == {"protocol": "data_processor", "usage_count": 12}
+
+    insight_types = sorted({i["type"] for i in result["insights"]})
+    assert insight_types == ["high_usage", "performance_issue", "repeated_failure"]
+
+    recs = result["recommendations"]
+    assert {r["mutation_type"] for r in recs} == {
+        "error_handling",
+        "performance_optimization",
+    }
+    # One error-handling recommendation per repeated failure, with the protocol
+    # name correctly extracted from each insight message.
+    error_handling = {
+        r["protocol"] for r in recs if r["mutation_type"] == "error_handling"
+    }
+    assert error_handling == {"data_processor", "api_health_checker"}
+    perf = [r for r in recs if r["mutation_type"] == "performance_optimization"]
+    assert [r["protocol"] for r in perf] == ["multimodal_llm_analyzer"]
+
+
+def test_slow_protocol_below_threshold_is_ignored():
+    # avg_duration <= 1.0s should not be reported as a slow protocol.
+    with patch.object(pd, "ensure_tables_exist", lambda: None), patch.object(
+        pd,
+        "get_db_connection",
+        lambda: _make_conn([[], [("fast_protocol", 0.5, 10)], []]),
+    ):
+        patterns = asyncio.run(pd.PatternDetector().detect_patterns())
+
+    assert patterns["performance_patterns"]["slow_protocols"] == []
+
+
+def test_detect_patterns_degrades_gracefully_on_db_error():
+    def boom():
+        raise RuntimeError("connection refused")
+
+    with patch.object(pd, "ensure_tables_exist", lambda: None), patch.object(
+        pd, "get_db_connection", boom
+    ):
+        result = asyncio.run(pd.PatternDetector().detect_patterns())
+
+    assert result["failure_patterns"]["repeated_failures"] == []
+    assert result["performance_patterns"]["slow_protocols"] == []
+    assert result["usage_patterns"]["top_protocols"] == []
+    assert "error" in result


### PR DESCRIPTION
## Summary

Follow-up to #109. `analyzers/pattern_detector.py` queried a local **SQLite** DB (`data/executor.db` / `execution_history`) that is never created or populated, while the rest of the system records executions in **PostgreSQL** via `utils/db_tracker` (`protocol_executions`). So `PatternDetector` never saw real data (and would raise `sqlite3.OperationalError: no such table`). This re-points it at the shared PostgreSQL store, as flagged by Gemini on #109.

## Changes

`PatternDetector.detect_patterns()` now reads from PostgreSQL via `utils.db_tracker.get_db_connection` / `ensure_tables_exist`:

- `execution_history` → `protocol_executions`, `timestamp` → `execution_time`, `success = 0` → `success = FALSE`.
- Per-execution **duration** lives in the JSONB `details` payload (`details ->> 'duration'`), so the slow-protocol query averages only numeric values (`details ? 'duration'` + a numeric regex guard before the `::float` cast).
- Graceful degradation preserved: on any DB error it returns empty pattern sets plus an `error` key (unchanged contract).
- Constructor simplified (the unused `db_path` is removed; nothing instantiated it with arguments).
- The pure-Python insight/recommendation logic (`generate_insights`, `generate_mutation_recommendations`, `analyze`) is **unchanged**.

## Tests

New `tests/test_pattern_detector.py` mocks the `db_tracker` connection helpers, so it runs **without a live PostgreSQL**. Covers:
- happy path — three result sets → patterns → insights → recommendations (incl. one `error_handling` rec per repeated failure, with correct protocol-name extraction);
- slow-protocol threshold (≤ 1.0s ignored);
- graceful degradation when the DB layer raises.

Written as plain sync functions wrapping `asyncio.run`, so they pass under stock pytest regardless of pytest-asyncio config. `pytest tests/test_pattern_detector.py` → **3 passed**.

## Verification notes

- ✅ `black --check .` clean (82 files), `flake8` clean on changed files, `ast.parse` OK.
- ⚠️ The SQL is PostgreSQL-specific (JSONB `->>`/`?`, `::float`, `~`). This environment has no Postgres server (`db_tracker` defaults to host `mcp_db`), so the queries were validated by careful review against the `protocol_executions` schema in `utils/db_tracker.py` and exercised via mocked cursors — not run against a live DB. Worth a quick sanity check against a real instance before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JA3CjME2QrfrKU3ZM5St8e)_